### PR TITLE
Refresh token fix

### DIFF
--- a/endpoint.json
+++ b/endpoint.json
@@ -84,11 +84,19 @@
       "required": true
     },
     {
-      "name": "redirectUri",
+      "name": "redirectUriLabel",
       "label": "Registered URI",
       "description": "Redirect URI to register on your application",
       "type": "label",
       "value": "config.SERVER_URL+ '/callback'"
+    },
+    {
+      "name": "redirectUri",
+      "label": "Registered URI",
+      "description": "Redirect URI to register on your application",
+      "type": "text",
+      "value": "config.SERVER_URL+ '/callback'",
+      "visibility": false
     },
     {
       "name": "webhook",

--- a/src/main/java/io/slingr/endpoints/gmelius/GmeliusEndpoint.java
+++ b/src/main/java/io/slingr/endpoints/gmelius/GmeliusEndpoint.java
@@ -69,7 +69,7 @@ public class GmeliusEndpoint extends HttpEndpoint {
             this.tokenManager = new TokenManager(httpService(), tokensDataStore, clientId, clientSecret, authorizationCode, codeVerifier, redirectUri);
             Executors.newSingleThreadScheduledExecutor().scheduleWithFixedDelay(tokenManager::refreshAccessToken, TOKEN_REFRESH_POLLING_TIME, TOKEN_REFRESH_POLLING_TIME, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
-            appLogger.error(String.format("Error refreshing token for client ID [%s]. You might need to get a new refresh token.", clientId));
+            appLogger.error(String.format("Error getting token for client ID [%s]. Endpoint should be redeployed.", clientId));
             throw e;
         }
     }

--- a/src/main/java/io/slingr/endpoints/gmelius/TokenManager.java
+++ b/src/main/java/io/slingr/endpoints/gmelius/TokenManager.java
@@ -66,6 +66,7 @@ public class TokenManager {
                     .post(formBody);
             this.refreshToken = refreshTokenResponse.string("refresh_token");
             this.accessToken = refreshTokenResponse.string("access_token");
+            appLogger.info("Tokens succefully retrieved on endpoint start");
             System.out.println("retrieved refreshToken " + refreshTokenResponse.string("refresh_token"));
             System.out.println("retrieved accessToken " + refreshTokenResponse.string("access_token"));
 


### PR DESCRIPTION
There was an issue in the endpoint configuration. The redirect uri was set as a label so the valu was not stored. Then we failed on getting the tokens for the first time and failed to refresh the tokens every 50 min